### PR TITLE
:bug: 修复 Message(res) 存在的CQ码注入问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ _✨ NoneBot2 在线运行代码<_ ✨_
 
 
 ## 更新日志
+0.0.8
+[@snowykami](https://github.com/snowykami)
+- 修复 Message(res) 存在的CQ码注入问题 [#10](https://github.com/yzyyz1387/nonebot_plugin_code/pull/10)
+
+0.0.7
+- 📜 添加 Metadata
+
+0.0.6
+[@ElainaFanBoy](https://github.com/ElainaFanBoy)
+- 适配 glot.io 所有语言 [#7](https://github.com/yzyyz1387/nonebot_plugin_code/pull/7) 
+
 
 0.0.5
  [@Limnium](https://github.com/Limnium)

--- a/nonebot_plugin_code/__init__.py
+++ b/nonebot_plugin_code/__init__.py
@@ -11,7 +11,7 @@
 # 更新了正则的pattern，完善了返回机制，“优化”代码风格。
 from nonebot import on_command
 from nonebot.params import CommandArg
-from nonebot.adapters.onebot.v11 import MessageEvent, Message, Bot, GroupMessageEvent
+from nonebot.adapters.onebot.v11 import MessageEvent, Message, Bot, GroupMessageEvent, MessageSegment
 from .run import run
 from nonebot.plugin import PluginMetadata
 
@@ -30,13 +30,18 @@ runcode = on_command('code', priority=5)
 async def runcode_body(bot: Bot, event: MessageEvent, arg: Message = CommandArg()):
     code = str(arg).strip()
     res = await run(code)
-    messages = {"type": "node", "data": {"name": "return", "uin": bot.self_id, "content": Message(res)}}
+    messages = {
+            "type": "node",
+            "data": {
+                    "name"   : "return",
+                    "uin"    : bot.self_id,
+                    "content": MessageSegment.text(res)
+                    }
+            }
     if isinstance(event, GroupMessageEvent):
         return await bot.call_api("send_group_forward_msg", group_id=event.group_id, messages=messages)
     else:
         return await bot.call_api("send_private_forward_msg", user_id=event.user_id, messages=messages)
-
-
 
 
 __usage__ = """

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r", encoding="utf-8", errors="ignore") as fh:
 
 setuptools.setup(
     name="nonebot_plugin_code",
-    version="0.0.7",
+    version="0.0.8",
     author="yzyyz1387",
     author_email="youzyyz1384@qq.com",
     keywords=("pip", "nonebot2", "nonebot", "nonebot_plugin"),


### PR DESCRIPTION
示例
```python
py code
print("[CQ:at,qq=all]")
```

在部门新生群看到招新公告机器人在用这个插件，然后一堆人搞CQ码注入把服务器文件都发出来了
![Uploading Image_1724057509655.png…]()
